### PR TITLE
Linux Arch support to grap png over lan connection

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -21,6 +21,11 @@ on your machine.  In a shell window:
     > cd rigol-grab
     > pipenv install
 
+It's also recommended to upgrade your scope's firmware. To check you firmware
+version on the scope. Go to Utility -> System -> System Info. Check the latest
+available firmware from [here](https://www.rigolna.com/firmware/) and
+instructions how to do the upgrade.
+
 ## Running rigol_grab
 
 First, plug the Rigol 'scope into your computer via USB cable or connect it to your network and note its IP address.  Then, in a shell window use these commands for a USB connection:

--- a/rigol_grab.py
+++ b/rigol_grab.py
@@ -7,11 +7,10 @@ import platform
 import subprocess
 import sys
 import pyvisa
-import time
 
 class RigolGrab(object):
 
-    VID_PID = '0x1AB1::0x04CE'.lower()
+    VID_PIDS = ['0x1AB1::0x04CE'.lower(), '6833::1230']
 
     def __init__(self, verbose=False):
         self._verbose = verbose
@@ -51,7 +50,11 @@ class RigolGrab(object):
         Find resource with matching VID_PID among list of names, or None
         if there is no match.
         '''
-        return next((s for s in names if self.VID_PID in s.lower()), None)
+        for name in names:
+            for vid_pid in self.VID_PIDS:
+                if vid_pid in name.lower():
+                    return name
+        return None
 
     def verbose_print(self, *args):
         if (self._verbose): print(*args)


### PR DESCRIPTION
Hello and thanks for this small script which also got me exited trying this out and to contribute to it.

Long story short. I have Linux Arch machine and the script didn't work for me out of the box. So here are some changes that I needed to do before it worked and some clean up.
* Remove unnecessary time import
* Change `VIP_PID` to be a list of supported identifiers. For some reason my machine returns identifier as 10-base number instead of hex.
* Modify the search function to account for this new change to loop over the identifier list.
* Add instructions to readme how to do the firmware upgrade. I needed to do this for this to work. I got timeout errors without it.
 
The tittle says that over lan connection because running this code doesn't work for me over usb. I get following error
```
/home/kazhuu/.local/share/virtualenvs/rigol-grab-ONTp5L5O/lib/python3.9/site-packages/pyvisa_py/protocols/usbtmc.py:115: UserWarning: Unexpected MsgID format. Consider updating the device's firmware. See https://github.com/pyvisa/pyvisa-py/issues/20
  warnings.warn(
Traceback (most recent call last):
  File "/home/kazhuu/programming/rigol-grab/rigol_grab.py", line 91, in <module>
    grabber.grab(filename=opts.filename, auto_view=opts.auto_view)
  File "/home/kazhuu/programming/rigol-grab/rigol_grab.py", line 22, in grab
    buf = self.rigol().query_binary_values(':DISP:DATA? ON,0,PNG', datatype='B')
  File "/home/kazhuu/.local/share/virtualenvs/rigol-grab-ONTp5L5O/lib/python3.9/site-packages/pyvisa/resources/messagebased.py", line 747, in query_binary_values
    return self.read_binary_values(
  File "/home/kazhuu/.local/share/virtualenvs/rigol-grab-ONTp5L5O/lib/python3.9/site-packages/pyvisa/resources/messagebased.py", line 602, in read_binary_values
    self.read_bytes(expected_length - len(block), chunk_size=chunk_size)
  File "/home/kazhuu/.local/share/virtualenvs/rigol-grab-ONTp5L5O/lib/python3.9/site-packages/pyvisa/resources/messagebased.py", line 371, in read_bytes
    chunk, status = self.visalib.read(self.session, size)
  File "/home/kazhuu/.local/share/virtualenvs/rigol-grab-ONTp5L5O/lib/python3.9/site-packages/pyvisa_py/highlevel.py", line 512, in read
    data, status_code = self.sessions[session].read(count)
  File "/home/kazhuu/.local/share/virtualenvs/rigol-grab-ONTp5L5O/lib/python3.9/site-packages/pyvisa_py/usb.py", line 149, in read
    return self._read(
  File "/home/kazhuu/.local/share/virtualenvs/rigol-grab-ONTp5L5O/lib/python3.9/site-packages/pyvisa_py/sessions.py", line 793, in _read
    current = reader()
  File "/home/kazhuu/.local/share/virtualenvs/rigol-grab-ONTp5L5O/lib/python3.9/site-packages/pyvisa_py/usb.py", line 133, in _usb_reader
    return self.interface.read(count)
  File "/home/kazhuu/.local/share/virtualenvs/rigol-grab-ONTp5L5O/lib/python3.9/site-packages/pyvisa_py/protocols/usbtmc.py", line 465, in read
    response = BulkInMessage.from_bytes(resp)
  File "/home/kazhuu/.local/share/virtualenvs/rigol-grab-ONTp5L5O/lib/python3.9/site-packages/pyvisa_py/protocols/usbtmc.py", line 113, in from_bytes
    msgid, btag, btaginverse = struct.unpack_from("BBBx", data)
struct.error: unpack_from requires a buffer of at least 4 bytes for unpacking 4 bytes at offset 0 (actual buffer size is 0)
```
I'm still digging in to this and trying to understand why. On linux for USB to work, you need to create udev rule to access usb device. Something along the lines
```
SUBSYSTEMS=="usb", ACTION=="add", ATTRS{idVendor}=="1ab1", ATTRS{idProduct}=="04ce", GROUP="usbtmc", MODE="0660"
```

These things could be added in the later PR if I figure out the problem.